### PR TITLE
Added Default Device Settings Method and Differential Restore Classes

### DIFF
--- a/MSSQL.BackupRestore/Interfaces/IBackupRestore.cs
+++ b/MSSQL.BackupRestore/Interfaces/IBackupRestore.cs
@@ -17,6 +17,7 @@ namespace MSSQL.BackupRestore.Interfaces
         event ServerMessageEventHandler Information;
         event PercentCompleteEventHandler PercentComplete;
 
+        BackupDeviceItem CreateDefaultDevice();
         Task ExecuteAsync(Server server, CancellationToken ct = default);
     }
 }

--- a/MSSQL.BackupRestore/Works/Abstracts/BackupBase.cs
+++ b/MSSQL.BackupRestore/Works/Abstracts/BackupBase.cs
@@ -133,6 +133,13 @@ namespace MSSQL.BackupRestore.Works.Abstracts
         /// <returns>A <see cref="BackupDeviceItem"/> representing the backup device.</returns>
         protected abstract BackupDeviceItem SetDevice();
 
+
+        /// <summary>
+        /// Sets the default backup device for the operation.
+        /// </summary>
+        /// <returns>A <see cref="BackupDeviceItem"/> representing the backup device.</returns>
+        public BackupDeviceItem CreateDefaultDevice() => new BackupDeviceItem(_filePath, DeviceType.File);
+
         /// <summary>
         /// Validates the file path for the backup operation.
         /// </summary>

--- a/MSSQL.BackupRestore/Works/Abstracts/RestoreBase.cs
+++ b/MSSQL.BackupRestore/Works/Abstracts/RestoreBase.cs
@@ -116,6 +116,12 @@ namespace MSSQL.BackupRestore.Works.Abstracts
         protected abstract BackupDeviceItem SetDevice();
 
         /// <summary>
+        /// Configures the restore device for the operation with default settings.
+        /// </summary>
+        /// <returns>A <see cref="BackupDeviceItem"/> representing the restore device.</returns>
+        public BackupDeviceItem CreateDefaultDevice() => new BackupDeviceItem(_filePath, DeviceType.File);
+
+        /// <summary>
         /// Initializes the restore operation by setting the file path and database name.
         /// </summary>
         /// <param name="filePath"></param>

--- a/MSSQL.BackupRestore/Works/BackupWorks/DifferentialBackup.cs
+++ b/MSSQL.BackupRestore/Works/BackupWorks/DifferentialBackup.cs
@@ -71,10 +71,6 @@ namespace MSSQL.BackupRestore.Works.BackupWorks
         /// Configures the backup device for the operation.
         /// </summary>
         /// <returns>A <see cref="BackupDeviceItem"/> representing the file device for the backup.</returns>
-        protected override BackupDeviceItem SetDevice()
-        {
-            return new BackupDeviceItem(_filePath, DeviceType.File);
-        }
+        protected override BackupDeviceItem SetDevice() => CreateDefaultDevice();
     }
-
 }

--- a/MSSQL.BackupRestore/Works/BackupWorks/FullBackup.cs
+++ b/MSSQL.BackupRestore/Works/BackupWorks/FullBackup.cs
@@ -79,10 +79,6 @@ namespace MSSQL.BackupRestore.Works.BackupWorks
         /// Configures the backup device for the operation.
         /// </summary>
         /// <returns>A <see cref="BackupDeviceItem"/> representing the file device for the backup.</returns>
-        protected override BackupDeviceItem SetDevice()
-        {
-            return new BackupDeviceItem(_filePath, DeviceType.File);
-        }
+        protected override BackupDeviceItem SetDevice() => CreateDefaultDevice();
     }
-
 }

--- a/MSSQL.BackupRestore/Works/BackupWorks/TransactionLogBackup.cs
+++ b/MSSQL.BackupRestore/Works/BackupWorks/TransactionLogBackup.cs
@@ -69,9 +69,6 @@ namespace MSSQL.BackupRestore.Works.BackupWorks
         /// Configures the backup device for the operation.
         /// </summary>
         /// <returns>A <see cref="BackupDeviceItem"/> representing the file device for the backup.</returns>
-        protected override BackupDeviceItem SetDevice()
-        {
-            return new BackupDeviceItem(_filePath, DeviceType.File);
-        }
+        protected override BackupDeviceItem SetDevice() => CreateDefaultDevice();
     }
 }

--- a/MSSQL.BackupRestore/Works/RestoreWorks/DifferentialRestore.cs
+++ b/MSSQL.BackupRestore/Works/RestoreWorks/DifferentialRestore.cs
@@ -12,28 +12,29 @@ using System.Threading.Tasks;
 namespace MSSQL.BackupRestore.Works.RestoreWorks
 {
     /// <summary>
-    /// Represents a full restore operation for an MSSQL database.
-    /// This class provides functionality to configure and execute a complete database restore.
+    /// Represents a differential restore operation for an MSSQL database.
+    /// This class provides functionality to configure and execute differential database restores.
     /// </summary>
-    public class FullRestore : RestoreBase
+    public class DifferentialRestore : RestoreBase
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="FullRestore"/> class with default restore settings.
+        /// Initializes a new instance of the <see cref="DifferentialRestore"/> class with default restore settings.
         /// </summary>
         /// <param name="databaseName">The name of the database to restore.</param>
-        /// <param name="filePath">The file path of the backup to restore from.</param>
+        /// <param name="filePath">The file path of the differential backup to restore from.</param>
         /// <param name="noRecovery">Indicates whether the database should remain in a restoring state after the restore operation. Defaults to <c>true</c>.</param>
         /// <param name="loggerFactory">Optional logger factory for creating loggers.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="filePath"/> is null.</exception>
-        public FullRestore(
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="filePath"/> is null or empty.</exception>
+        /// <exception cref="BackupRestoreException">Thrown if the specified file path does not exist.</exception>
+        public DifferentialRestore(
             string databaseName,
             string filePath,
             bool noRecovery = true,
             ILoggerFactory loggerFactory = null)
-            : base(loggerFactory?.CreateLogger<FullRestore>(), databaseName, (restore) =>
+            : base(loggerFactory?.CreateLogger<DifferentialRestore>(), databaseName, (restore) =>
             {
                 restore.Action = RestoreActionType.Database;
-                restore.ReplaceDatabase = true;
+                restore.ReplaceDatabase = false;
                 restore.PercentCompleteNotification = 1;
                 restore.ContinueAfterError = true;
                 restore.NoRecovery = noRecovery;
@@ -43,19 +44,20 @@ namespace MSSQL.BackupRestore.Works.RestoreWorks
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="FullRestore"/> class with custom restore settings.
+        /// Initializes a new instance of the <see cref="DifferentialRestore"/> class with custom restore settings.
         /// </summary>
         /// <param name="databaseName">The name of the database to restore.</param>
-        /// <param name="filePath">The file path of the backup to restore from.</param>
+        /// <param name="filePath">The file path of the differential backup to restore from.</param>
         /// <param name="configureRestore">A delegate to customize the restore configuration.</param>
         /// <param name="loggerFactory">Optional logger factory for creating loggers.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="filePath"/> is null.</exception>
-        public FullRestore(
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="filePath"/> is null or empty.</exception>
+        /// <exception cref="BackupRestoreException">Thrown if the specified file path does not exist.</exception>
+        public DifferentialRestore(
             string databaseName,
             string filePath,
             Action<Restore> configureRestore,
             ILoggerFactory loggerFactory = null)
-            : base(loggerFactory?.CreateLogger<FullRestore>(), databaseName, configureRestore)
+            : base(loggerFactory?.CreateLogger<DifferentialRestore>(), databaseName, configureRestore)
         {
             Initialize(filePath, databaseName);
         }
@@ -63,23 +65,23 @@ namespace MSSQL.BackupRestore.Works.RestoreWorks
         /// <summary>
         /// Initializes the restore operation by validating the file path and logging the setup.
         /// </summary>
-        /// <param name="filePath">The file path of the backup to restore from.</param>
+        /// <param name="filePath">The file path of the differential backup to restore from.</param>
         /// <param name="databaseName">The name of the database to restore.</param>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="filePath"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="filePath"/> is null or empty.</exception>
+        /// <exception cref="BackupRestoreException">Thrown if the specified file path does not exist.</exception>
         protected override void Initialize(string filePath, string databaseName)
         {
             ValidateFilePath(filePath);
             _filePath = filePath;
             if (!IsFileExists(filePath))
-                throw new BackupRestoreException(new FileNotFoundException("The backup file does not exist.", filePath));
-            _logger?.LogDebug("Initializing full restore for database {databaseName} with file path {filePath}", databaseName, filePath);
+                throw new BackupRestoreException(new FileNotFoundException("The specified backup file does not exist.", filePath));
+            _logger?.LogDebug("Initialized differential restore operation for database {DatabaseName} from file {FilePath}.", databaseName, filePath);
         }
 
         /// <summary>
-        /// Configures the restore device for the operation.
+        /// Configures the restore device for the differential restore operation.
         /// </summary>
-        /// <returns>A <see cref="BackupDeviceItem"/> representing the file device for the restore operation.</returns>
+        /// <returns>A <see cref="BackupDeviceItem"/> representing the device for the restore operation.</returns>
         protected override BackupDeviceItem SetDevice() => CreateDefaultDevice();
     }
-
 }


### PR DESCRIPTION
Added method 'CreateDefaultDevice' to interface 'IBackupRestore'. The 'CreateDefaultDevice' method was added to the 'BackupBase' and 'RestoreBase' classes to allow you to set the default device. In the classes 'DifferentialBackup', 'FullBackup', 'TransactionLogBackup', and 'FullRestore', the 'SetDevice' method has been changed to invoke the 'CreateDefaultDevice' method. A new class of 'Differential Restore' has been added to support differential restore operations of MSSQL databases.