### PR TITLE
The IBackupRestore interface has changed from internal to public.

### DIFF
--- a/MSSQL.BackupRestore/Interfaces/IBackupRestore.cs
+++ b/MSSQL.BackupRestore/Interfaces/IBackupRestore.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace MSSQL.BackupRestore.Interfaces
 {
-    internal interface IBackupRestore
+    public interface IBackupRestore
     {
         string DatabaseName { get; }
 
@@ -17,7 +17,6 @@ namespace MSSQL.BackupRestore.Interfaces
         event ServerMessageEventHandler Information;
         event PercentCompleteEventHandler PercentComplete;
 
-        BackupDeviceItem CreateDefaultDevice();
         Task ExecuteAsync(Server server, CancellationToken ct = default);
     }
 }

--- a/MSSQL.BackupRestore/Interfaces/IRecoveryJob.cs
+++ b/MSSQL.BackupRestore/Interfaces/IRecoveryJob.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MSSQL.BackupRestore.Interfaces
+{
+    public interface IRecoveryJob
+    {
+        void AddBackupRestore(IBackupRestore backupRestore);
+    }
+}

--- a/MSSQL.BackupRestore/Interfaces/IWorkSet.cs
+++ b/MSSQL.BackupRestore/Interfaces/IWorkSet.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.SqlServer.Management.Smo;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MSSQL.BackupRestore.Interfaces
+{
+    public interface IWorkSet
+    {
+        BackupDeviceItem CreateDefaultDevice();
+    }
+}

--- a/MSSQL.BackupRestore/Works/Abstracts/BackupBase.cs
+++ b/MSSQL.BackupRestore/Works/Abstracts/BackupBase.cs
@@ -22,7 +22,7 @@ namespace MSSQL.BackupRestore.Works.Abstracts
     /// Provides functionality for configuring backup devices, executing backups, 
     /// and handling events related to backup progress and completion.
     /// </summary>
-    public abstract class BackupBase : IBackupRestore, IFileSystem
+    public abstract class BackupBase : IBackupRestore, IFileSystem, IWorkSet
     {
         /// <summary>
         /// Logger instance for recording log messages related to backup operations.

--- a/MSSQL.BackupRestore/Works/Abstracts/RestoreBase.cs
+++ b/MSSQL.BackupRestore/Works/Abstracts/RestoreBase.cs
@@ -17,7 +17,7 @@ namespace MSSQL.BackupRestore.Works.Abstracts
     /// Base class for database restore operations in MSSQL.
     /// Provides common functionality for configuring and executing restore tasks.
     /// </summary>
-    public abstract class RestoreBase : FileSystem, IBackupRestore, INoRecoverable 
+    public abstract class RestoreBase : FileSystem, IBackupRestore, INoRecoverable, IWorkSet
     {
         /// <summary>
         /// Logger instance for recording restore operation events and debugging information.

--- a/MSSQL.BackupRestore/Works/RestoreWorks/RecoveryJob.cs
+++ b/MSSQL.BackupRestore/Works/RestoreWorks/RecoveryJob.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.SqlServer.Management.Common;
+using Microsoft.SqlServer.Management.Smo;
+using MSSQL.BackupRestore.Exceptions;
+using MSSQL.BackupRestore.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MSSQL.BackupRestore.Works.RestoreWorks
+{
+    public class RecoveryJob : IBackupRestore, IRecoveryJob
+    {
+        private const string BACKUP_EXTENSION = ".bak";
+        private const string LOG_EXTENSION = ".trn";
+
+        private IList<IBackupRestore> _backupRestoreList = new List<IBackupRestore>();
+        private readonly ILogger _logger;
+
+        public string DatabaseName { get; }
+
+        public event ServerMessageEventHandler Complete;
+        public event ServerMessageEventHandler Information;
+        public event PercentCompleteEventHandler PercentComplete;
+
+        public void AddBackupRestore(IBackupRestore backupRestore)
+        {
+            if (backupRestore is null)
+                throw new ArgumentNullException(nameof(backupRestore));
+
+            if (backupRestore.DatabaseName != DatabaseName)
+                throw new ArgumentException("Database name must match the recovery job database name.", nameof(backupRestore));
+
+            if (backupRestore is FullRestore fullRestore)
+            {
+                if (_backupRestoreList.Any(x => x is FullRestore))
+                    throw new InvalidOperationException("Only one full restore operation is allowed per recovery job.");
+            }
+
+            if (backupRestore is DifferentialRestore differentialRestore)
+            {
+                if (_backupRestoreList.Any(x => x is DifferentialRestore))
+                    throw new InvalidOperationException("Only one differential restore operation is allowed per recovery job.");
+            }
+
+            backupRestore.Complete += (sender, e) => Complete?.Invoke(sender, e);
+            backupRestore.Information += (sender, e) => Information?.Invoke(sender, e);
+            backupRestore.PercentComplete += (sender, e) => PercentComplete?.Invoke(sender, e);
+
+            _backupRestoreList.Add(backupRestore);
+        }
+
+        public void FullRestore(string filePath)
+        {
+            if (string.IsNullOrWhiteSpace(filePath))
+                throw new ArgumentException("File path cannot be null or empty.", nameof(filePath));
+            if (!File.Exists(filePath))
+                throw new FileNotFoundException("Backup file not found.", filePath);
+            if (!IsBackupFile(filePath))
+                throw new BackupRestoreException(filePath, "Invalid backup file extension.");
+
+            AddBackupRestore(new FullRestore(DatabaseName, filePath));
+        }
+
+        private static bool IsBackupFile(string filePath)
+        {
+            return Path.GetExtension(filePath) == BACKUP_EXTENSION || Path.GetExtension(filePath) == LOG_EXTENSION;
+        }
+
+        public Task ExecuteAsync(Server server, CancellationToken ct = default)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MSSQL.BackupRestore/Works/RestoreWorks/TransactionLogRestore.cs
+++ b/MSSQL.BackupRestore/Works/RestoreWorks/TransactionLogRestore.cs
@@ -1,0 +1,94 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.SqlServer.Management.Smo;
+using MSSQL.BackupRestore.Exceptions;
+using MSSQL.BackupRestore.Works.Abstracts;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MSSQL.BackupRestore.Works.RestoreWorks
+{
+    /// <summary>
+    /// Represents a transaction log restore operation for an MSSQL database.
+    /// This class provides functionality to configure and execute transaction log restores,
+    /// allowing point-in-time recovery of the database.
+    /// </summary>
+    public class TransactionLogRestore : RestoreBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TransactionLogRestore"/> class with default restore settings.
+        /// </summary>
+        /// <param name="databaseName">The name of the database to restore.</param>
+        /// <param name="filePath">The file path of the transaction log backup to restore from.</param>
+        /// <param name="noRecovery">
+        /// Indicates whether the database should remain in a restoring state after the restore operation.  
+        /// Set to <c>true</c> to allow additional restore operations (e.g., applying multiple log backups).  
+        /// Defaults to <c>true</c>.
+        /// </param>
+        /// <param name="loggerFactory">Optional logger factory for creating loggers.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="filePath"/> is null or empty.</exception>
+        /// <exception cref="BackupRestoreException">Thrown if the specified file path does not exist.</exception>
+        public TransactionLogRestore(
+            string databaseName,
+            string filePath,
+            bool noRecovery = true,
+            ILoggerFactory loggerFactory = null)
+            : base(loggerFactory?.CreateLogger<TransactionLogRestore>(), databaseName, (restore) =>
+            {
+                restore.Action = RestoreActionType.Log;
+                restore.ReplaceDatabase = false;
+                restore.PercentCompleteNotification = 1;
+                restore.ContinueAfterError = true;
+                restore.NoRecovery = noRecovery;
+            })
+        {
+            Initialize(filePath, databaseName);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TransactionLogRestore"/> class with custom restore settings.
+        /// </summary>
+        /// <param name="databaseName">The name of the database to restore.</param>
+        /// <param name="filePath">The file path of the transaction log backup to restore from.</param>
+        /// <param name="configureRestore">A delegate to customize the restore configuration.</param>
+        /// <param name="loggerFactory">Optional logger factory for creating loggers.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="filePath"/> is null or empty.</exception>
+        /// <exception cref="BackupRestoreException">Thrown if the specified file path does not exist.</exception>
+        public TransactionLogRestore(
+            string databaseName,
+            string filePath,
+            Action<Restore> configureRestore,
+            ILoggerFactory loggerFactory = null)
+            : base(loggerFactory?.CreateLogger<TransactionLogRestore>(), databaseName, configureRestore)
+        {
+            Initialize(filePath, databaseName);
+        }
+
+        /// <summary>
+        /// Initializes the restore operation by validating the file path and logging the setup.
+        /// </summary>
+        /// <param name="filePath">The file path of the transaction log backup to restore from.</param>
+        /// <param name="databaseName">The name of the database to restore.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="filePath"/> is null or empty.</exception>
+        /// <exception cref="BackupRestoreException">Thrown if the specified file path does not exist.</exception>
+        protected override void Initialize(string filePath, string databaseName)
+        {
+            ValidateFilePath(filePath);
+            _filePath = filePath;
+            if (!IsFileExists(filePath))
+                throw new BackupRestoreException(new FileNotFoundException("The Backup file does not exist.", filePath));
+
+            _logger.LogDebug("Initialized Transaction Log Restore operation for database '{DatabaseName}' from file '{FilePath}'.", databaseName, filePath);
+        }
+
+        /// <summary>
+        /// Configures the restore device for the transaction log restore operation.
+        /// </summary>
+        /// <returns>A <see cref="BackupDeviceItem"/> representing the device for the restore operation.</returns>
+        protected override BackupDeviceItem SetDevice() => CreateDefaultDevice();
+    }
+
+}


### PR DESCRIPTION
Additionally, the CreateDefaultDevice method has been removed. The IWorkSet interface was added to the BackupBase and RestoreBase classes. A new IR Recovery Job interface has been added and includes the AddBackupRestore method. A new IWorkSet interface has been added and includes the CreateDefaultDevice method. A new Recovery Job class has been added, implementing the IBackupRestore and the IR Recovery Job interface. A new TransactionLogRestore class has been added, inheriting RestoreBase.